### PR TITLE
We also report UUID in a human readable form

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = g++
 ARCH=sm_35
 
 stream : stream.cu Makefile
-	nvcc -std=c++11 -ccbin=$(CC) stream.cu -arch=$(ARCH) -o stream
+	nvcc -std=c++11 -ccbin=$(CC) stream.cu -arch=$(ARCH) -o stream -lnvidia-ml
 
 .PHONY: clean
 clean :

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = g++
-ARCH=sm_35
+ARCH=sm_70
 
 stream : stream.cu Makefile
 	nvcc -std=c++11 -ccbin=$(CC) stream.cu -arch=$(ARCH) -o stream -lnvidia-ml

--- a/stream.cu
+++ b/stream.cu
@@ -36,6 +36,8 @@ Further modifications by: Ben Cumming, CSCS; Andreas Herten (JSC/FZJ); Sebastian
 #include <getopt.h>
 
 #include <chrono>
+#include <nvml.h>
+#include <iostream>
 
 # ifndef MIN
 # define MIN(x,y) ((x)<(y)?(x):(y))
@@ -166,6 +168,14 @@ __global__ void STREAM_Triad(T const * __restrict__ a, T const * __restrict__ b,
 
 int main(int argc, char** argv)
 {
+  nvmlInit();
+
+  nvmlDevice_t device;
+  nvmlDeviceGetHandleByIndex_v2(0, &device);
+  char uuid[100];
+  nvmlDeviceGetUUID(device, uuid, 100);
+  std::cout<<"Device UUID = " << uuid<<"\n";
+
   real *d_a, *d_b, *d_c;
   int j,k;
   double times[4][NTIMES];
@@ -307,5 +317,7 @@ int main(int argc, char** argv)
   cudaFree(d_a);
   cudaFree(d_b);
   cudaFree(d_c);
+
+  nvmlShutdown();
 }
 


### PR DESCRIPTION
Reporting UUID like this has an advantage of quickly mapping the benchmark to a unique device.
I also bumped up the architecture to sm_70 as sm_35 is not compilable by CUDA 12.2 anymore. 